### PR TITLE
fix: fix failing search when string starts with uppercase

### DIFF
--- a/src/components/Typeahead.vue
+++ b/src/components/Typeahead.vue
@@ -165,7 +165,7 @@ export default {
       }
 
       self.previous = window.setTimeout(function() {
-        var p = window.fuzzySearcher.find(self.currentQuery);
+        var p = window.fuzzySearcher.find(self.currentQuery.toLowerCase());
 
         if (Array.isArray(p)) {
           self.suggestions = p.map(toOwnSuggestion);


### PR DESCRIPTION
This is a workaround for some underlying bug:

If I search for "ActivityWatch" it gets stuck on "Downloading search index for letter A...", but if a is lowercased then it immediately loads. 

I haven't rested it locally (doing this on my phone).


Note: Awesome project btw!